### PR TITLE
fix: upgrade vite to stable for Vercel build

### DIFF
--- a/viz/package.json
+++ b/viz/package.json
@@ -23,9 +23,6 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
     "globals": "^16.5.0",
-    "vite": "^8.0.0-beta.13"
-  },
-  "overrides": {
-    "vite": "^8.0.0-beta.13"
+    "vite": "^8.0.5"
   }
 }


### PR DESCRIPTION
## Problem

Vercel build fails with:
```
sh: line 1: vite: command not found
Error: Command "vite build" exited with 127
```

## Fix

- Upgraded `vite` from `^8.0.0-beta.13` (beta) to `^8.0.5` (stable)
- Removed `overrides` block (no longer needed with stable release)

## To test

Merge this PR — Vercel should auto-deploy successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)