### PR TITLE
fix(#419): 'pay back the debt' → 'pay back their debt' in ConsolesPage

### DIFF
--- a/viz/src/App2.jsx
+++ b/viz/src/App2.jsx
@@ -2081,7 +2081,7 @@ function ConsolesPage() {
     <div>
       <h2 style={{ fontSize: 22, fontWeight: 700, color: TEXT, margin: "0 0 16px" }}>Does Government Debt Have to Be Repaid?</h2>
       <p style={{ fontSize: 15, color: TEXT, lineHeight: 1.75, margin: "0 0 16px" }}>
-        A common misunderstanding is that someday governments will have to pay back the debt. Because creditors have to believe that people will be able to pay off their debts during their lifetimes, people can't run up unlimited debts. But governments don't have an expected lifetime so their ability to borrow isn't limited in the same way.
+        A common misunderstanding is that someday governments will have to pay back their debt. Because creditors have to believe that people will be able to pay off their debts during their lifetimes, people can't run up unlimited debts. But governments don't have an expected lifetime so their ability to borrow isn't limited in the same way.
       </p>
       <p style={{ fontSize: 15, color: TEXT, lineHeight: 1.75, margin: "0 0 16px" }}>
         In fact many governments have issued debt that they never have to pay back — called <em>consoles</em> — and people bought them. Consoles pay interest, but the loan itself never has to be repaid. In fact, one such bond issued by the Dutch government in the 1600s was still paying interest a few years ago.


### PR DESCRIPTION
## Summary

One-line copy fix flagged by Bill on the visualizepolicy.org preview. After PR #7 changed \"the government\" → \"governments\" (plural) in the debt-console intro, the follow-on clause \"pay back the debt\" read awkwardly — Bill asked for \"pay back their debt\" so the possessive matches the new plural subject.

The visualizepolicy.org deploy already ships this wording (in the patched bundle from rdhyee/obbba-dashboard#420). This PR brings the source in line so future bundle rebuilds don't silently regress the fix.

## Scope

- Single line in `viz/src/App2.jsx` (`ConsolesPage`, line 2084).
- The other three \"pay back the debt\" occurrences in `App2.jsx` are in singular / US-specific currency / inflation contexts where no plural mismatch exists — left untouched on purpose.

## Test plan

- [ ] Visual diff: open Budget Explorer → debt console → first paragraph reads \"…governments will have to pay back **their** debt.\"
- [ ] No other text changes anywhere on the site.

## Notes for review

This is a canary PR — first time merging upstream during Aadit's 10-day offline window. Picked the smallest possible change to verify the Vercel auto-deploy pipeline (viz-smoky.vercel.app) fires correctly on merge, before touching anything riskier (e.g., the upstream fix for #8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)