### PR TITLE
Move "Back to the Impact Map" button to the final slide

### DIFF
--- a/viz/src/App2.jsx
+++ b/viz/src/App2.jsx
@@ -533,7 +533,7 @@ var TOUR_CONFIGS = {
     { title: "Hover a slice", body: "Click any slice of the donut to see what that category costs, why it's hard to cut, and polling data on public support. Red slices are mandatory spending — legally required by statute. Green slices are discretionary." },
     { title: "The math is brutal", body: "Even eliminating every green slice entirely: all of defense, education, veterans, foreign aid. It barely covers the deficit. Any plan to balance the budget requires some combination of cuts to mandatory programs, discretionary programs, and tax increases." },
   ],
-  // Page 13 — Balancing the Budget
+  // Page 13 — Your Fiscal Scenario
   13: [
     { title: "Drag the sliders", body: "Each slider raises the effective tax rate on that income group by up to 20 percentage points. The bar at the top fills in green as you close more of the deficit." },
     { title: "The static vs. real gap", body: "These numbers assume people keep earning and reporting the same income. In reality, higher rates lead to more deductions, income shifting, and deferral. The true revenue gain is real but smaller than what you see here." },
@@ -3754,13 +3754,6 @@ function TaxPage({ taxData, cboBaseline, cuts, setCuts, ratesRaw, setRatesRaw })
         Sustainable range reference: <a href="https://www.cbo.gov/publication/61882" target="_blank" rel="noreferrer" style={{ color: BLUE }}>CBO, The Budget and Economic Outlook: 2026 to 2036</a>.
         The 40–60% band approximates the 50‑year historical average for debt held by the public.
       </p>
-
-      <div style={{ textAlign: "center", marginTop: 24, paddingTop: 20, borderTop: "1px solid " + BORDER }}>
-        <a href="/obbba/" style={{
-          display: "inline-block", padding: "10px 24px", background: BLUE, color: "#fff",
-          borderRadius: 8, textDecoration: "none", fontSize: 15, fontWeight: 600,
-        }}>← Back to the Impact Map</a>
-      </div>
     </div>
   );
 }
@@ -6567,8 +6560,16 @@ function PageShell({ page, setPage, children, prompt }) {
           </button>
         )}
         {page === total - 1 && (
-          <div style={{ textAlign: "center", fontSize: 13, color: MUTED, paddingBottom: 12 }}>
-            End of tour · <a href="https://visualizepolicy.org" style={{ color: "#1e3a5f" }}>Visualize Policy</a>
+          <div style={{ textAlign: "center", paddingBottom: 12 }}>
+            <div style={{ marginBottom: 16 }}>
+              <a href="/obbba/" style={{
+                display: "inline-block", padding: "10px 24px", background: BLUE, color: "#fff",
+                borderRadius: 8, textDecoration: "none", fontSize: 15, fontWeight: 600,
+              }}>← Back to the Impact Map</a>
+            </div>
+            <div style={{ fontSize: 13, color: MUTED }}>
+              End of tour · <a href="https://visualizepolicy.org" style={{ color: "#1e3a5f" }}>Visualize Policy</a>
+            </div>
           </div>
         )}
       </div>


### PR DESCRIPTION
Small UI cleanup, independent of #14 (no overlapping lines).

## Changes (all in `viz/src/App2.jsx`)

**1. Move the "← Back to the Impact Map" button to the final slide.**
It previously sat at the bottom of the **Your Fiscal Scenario** page (`TaxPage`, page 13), so it surfaced mid-flow. Moved it into the `PageShell` final-slide block (`page === total - 1` — the last page, *Your Representatives' Fiscal Record*), placed above the existing "End of tour · Visualize Policy" footer. Same inline-link styling; still links to `/obbba/`. Variant-agnostic (works regardless of which RepresentativesPage variant renders).

**2. Tidy a stale comment.** `// Page 13 — Balancing the Budget` → `// Page 13 — Your Fiscal Scenario`.

## Note on the "Balancing the Budget" title
The page title users see in the top-right / section banner is already correct in `main` — it renders `pageMeta.title` = "Your Fiscal Scenario" (renamed in `120db27`). The old title only appears on stale builds (e.g. #14's preview, which branched before the rename). No UI change was needed beyond the comment; a full repo scan found no other stale references.

## Verification
- `npm run build` — clean.
- Manually: button gone from Your Fiscal Scenario page; appears on the last page above "End of tour".